### PR TITLE
Setup mocks for Expo.Svg components

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -120,3 +120,30 @@ Object.defineProperty(ReactNative, 'Modal', {
   enumerable: true,
   get: () => Modal,
 });
+
+/* mock Expo.Svg */
+const React = require.requireActual('react');
+
+function createSvgComponentMock(name, actualComponent) {
+  class SvgComponentMock extends React.Component {
+    render() {
+      return React.createElement(name, this.props, this.props.children);
+    }
+  }
+  SvgComponentMock.displayName = actualComponent.displayName;
+  SvgComponentMock.propTypes = actualComponent.propTypes;
+  return SvgComponentMock;
+}
+
+const Svg = createSvgComponentMock('Svg', Expo.Svg);
+const excludedKeys = ['displayName', 'propTypes', 'defaultProps'];
+const componentsToMock = Object.keys(Expo.Svg)
+  .filter(key => !excludedKeys.includes(key));
+for (let name of componentsToMock) {
+  Svg[name] = createSvgComponentMock(name, Expo.Svg[name]);
+}
+
+Object.defineProperty(Expo, 'Svg', {
+  enumerable: true,
+  get: () => Svg,
+});


### PR DESCRIPTION
My snapshot tests that used `Expo.Svg` components were all failing. Turns out I had to setup mocks for those components - so this introduces those mocks into `jest-expo` so you can use them in tests out of the box.

This is heavily inspired by the discussion under react-native-community/react-native-svg#198.