### PR TITLE
Add location strings to asset mock

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -89,6 +89,8 @@ for (let moduleName of Object.keys(expoModules)) {
 jest.mock('react-native/Libraries/Image/AssetRegistry', () => ({
   registerAsset: jest.fn(() => 1),
   getAssetByID: jest.fn(() => ({
+    fileSystemLocation: '/full/path/to/directory',
+    httpServerLocation: '/assets/full/path/to/directory',
     scales: [1],
     fileHashes: ['md5'],
     name: 'name',


### PR DESCRIPTION
My tests were failing because [resolveAssetSource](https://github.com/facebook/react-native/blob/master/Libraries/Image/resolveAssetSource.js) needs assets to have `httpServerLocation` defined. This PR fixes the issue by adding in `httpServerLocation` (and `fileSystemLocation` just in case) to the asset mock defined by jest-expo.