### PR TITLE
Whitelist sentry-expo to be transformed

### DIFF
--- a/jest-preset.json
+++ b/jest-preset.json
@@ -22,7 +22,7 @@
     "<rootDir>/node_modules/react-native/Libraries/react-native/"
   ],
   "transformIgnorePatterns": [
-    "node_modules/(?!((jest-)?react-native|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation))"
+    "node_modules/(?!((jest-)?react-native|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation|sentry-expo))"
   ],
   "setupFiles": [
     "<rootDir>/node_modules/react-native/jest/setup.js",


### PR DESCRIPTION
Adds `sentry-expo` to the whitelist in `transformIgnorePatterns`.
`sentry-expo` is untranspiled, so my Jest tests were erroring when it
wasn't transformed.