### PR TITLE
bump jest and babel-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "react-native": "*"
   },
   "dependencies": {
-    "babel-jest": "^21.2.0",
-    "jest": "^21.2.1",
+    "babel-jest": "^22.0.6",
+    "jest": "^22.0.6",
     "json5": "^0.5.1",
     "react-test-renderer": "16.0.0"
   },


### PR DESCRIPTION
People checking out crna cannot run `npm test` (which runs `jest --watch`) because of a bug in version 21 of jest https://github.com/facebook/jest/issues/4419

See forums post: https://forums.expo.io/t/jest-not-working-on-new-crna/6292/2

TODO: not sure how to test that this bump is safe @brentvatne 