### PR TITLE
No need for "./node_modules/.bin" prefix on script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ at https://github.com/expo/expo. Thanks!
 
   ```js
   "scripts": {
-    "test": "node_modules/.bin/jest"
+    "test": "jest"
   },
   "jest": {
     "preset": "jest-expo"


### PR DESCRIPTION
Anything in `.bin` is automatically available in scripts so that is not needed.